### PR TITLE
Add beginning of testing framework

### DIFF
--- a/bookcut/__init__.py
+++ b/bookcut/__init__.py
@@ -1,0 +1,2 @@
+from importlib import metadata
+__version__ = metadata.version("bookcut")

--- a/bookcut/book.py
+++ b/bookcut/book.py
@@ -84,20 +84,6 @@ class Booksearch:
                 except Exception as e:
                     pass
 
-                '''
-                row = [tr.text for tr in td]
-                table_data.append(row)
-                extensions.append(row[8])
-                table_details = dict()
-                table_details['extensions'] = extensions
-                table_details['table_data'] = table_data
-                table_details['mirrors'] = mirrors
-                print(table_details)
-                return table_details
-            else:
-                print('\nNo results found or bad Internet connection.')
-                print('Please,try again.') '''
-
     def give_result(self, extensions, table_data, mirrors, filetype):
         try:
             if filetype is not None:

--- a/bookcut/bookcut.py
+++ b/bookcut/bookcut.py
@@ -1,6 +1,7 @@
 import click
 import pyfiglet
 from os import name, system
+from bookcut import __version__
 from bookcut.mirror_checker import main as mirror_checker
 from bookcut.book import book_find
 from bookcut.organise import main_organiser
@@ -14,7 +15,7 @@ from bookcut.booklist import booklist_main
 
 
 @click.group(name='commands')
-@click.version_option(version="1.3.3")
+@click.version_option(version=__version__)
 def entry():
     """
     for a single book download you can \n

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
 minversion = 6.0
-addopts = -ra --cov=bookcut
 testpaths =
     tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+minversion = 6.0
+addopts = -ra --cov=bookcut
+testpaths =
+    tests

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,12 @@ setuptools.setup(
             'pyfiglet',
             'tqdm',
             'mechanize'],
+    extras_require={
+        'dev': [
+            'pytest',
+            'pytest-cov',
+        ]
+    },
     include_package_data=True,
     entry_points='''
             [console_scripts]

--- a/tests/test_bookcut.py
+++ b/tests/test_bookcut.py
@@ -1,0 +1,9 @@
+from click.testing import CliRunner
+from bookcut import __version__
+from bookcut.bookcut import entry
+
+
+def test_entry_with_version_option():
+    cli_output = CliRunner().invoke(entry, ["--version"])
+    assert cli_output.exit_code == 0
+    assert cli_output.output == f"commands, version {__version__}\n"

--- a/tests/test_bookcut.py
+++ b/tests/test_bookcut.py
@@ -1,9 +1,40 @@
+import pytest
+
 from click.testing import CliRunner
 from bookcut import __version__
 from bookcut.bookcut import entry
-
+from bookcut.mirror_checker import openLibraryStatus, main as mirror_checker
+from bookcut.book import book_find
+from bookcut.book import Booksearch
 
 def test_entry_with_version_option():
     cli_output = CliRunner().invoke(entry, ["--version"])
     assert cli_output.exit_code == 0
     assert cli_output.output == f"commands, version {__version__}\n"
+
+
+class TestBookCut:
+    def test_mirror_availability(self):
+        global available_mirror
+        available_mirror = mirror_checker()
+        assert type(available_mirror) is str, "Not correct type of LibGen Url"
+        assert available_mirror.startswith('http'), "Not correct LibGen Url."
+
+    def test_open_libraryStatus(self):
+        status = openLibraryStatus()
+        assert status is not False, "OpenLibrary Status =! 200"
+
+    def test_single_book_download(self):
+        title = "Sapiens"
+        author = "Harari"
+        publisher = " "
+        type_format = ' '
+        book = Booksearch(title, author, publisher, type_format, available_mirror)
+        result = book.search()
+        extensions = result['extensions']
+        print('extensions: ', extensions)
+        tb = result['table_data']
+        mirrors = result['mirrors']
+        assert mirrors[0].startswith("http"), "Not correct format of Mirror URL."
+        assert type(extensions) is list, "Wrong format of extension details."
+        file_details = book.give_result(extensions, tb, mirrors, extensions[0])


### PR DESCRIPTION
Hi, awesome project you have there.
Unfortunately, without tests it is difficult to contribute because you are never sure if you break stuff.

This is a suggestion how testing with pytest could work.

When you install the package you can now also install the "dev" extra, which pulls in pytest by running `pip install -e '.[dev]'`.
Now you can always run `pytest` in the base directory of the project to execute all tests and get a nice coverage report.

The example test I created only tests if the output of the `--version` option really gives the correct version number, which was not the case, which is why I fixed that too.
