### PR TITLE
Fix #22

### DIFF
--- a/bookcut/Settings.ini
+++ b/bookcut/Settings.ini
@@ -1,5 +1,5 @@
 [LibGen]
-mirrors = https://libgen.is/,http://libgen.li/,http://185.39.10.101/,http://genesis.lib/
+mirrors = https://libgen.is/,https://libgen.rs/,http://libgen.li/,http://185.39.10.101/,http://genesis.lib/
 
 [Repositories]
 available_repos = arxiv,libgen

--- a/bookcut/Settings.ini
+++ b/bookcut/Settings.ini
@@ -1,5 +1,5 @@
 [LibGen]
-mirrors = https://libgen.lc/,http://libgen.li/,http://185.39.10.101/,http://genesis.lib/
+mirrors = https://libgen.is/,http://libgen.li/,http://185.39.10.101/,http://genesis.lib/
 
 [Repositories]
 available_repos = arxiv,libgen


### PR DESCRIPTION
https://libgen.lc/ uses a new interface. Easiest solution: Switch to https://libgen.is/ which uses the old interface.
Also https://libgen.lc/ uses form id `formlibgen` with `enctype=multipart/form-data` which is not recognized as a valid encoding type for GET requests by `mechanize`, so this would be a bit more work to update properly.